### PR TITLE
Log warning when starting Emacs in terminal

### DIFF
--- a/fontaine.el
+++ b/fontaine.el
@@ -477,7 +477,7 @@ Set `fontaine-current-preset' to PRESET.  Also see the command
 Call `fontaine-set-preset-hook' as a final step."
   (interactive (list (fontaine--set-fonts-prompt) current-prefix-arg))
   (if (and (not (daemonp)) (not window-system))
-      (user-error "Cannot use this in a terminal emulator; try the Emacs GUI")
+      (display-warning "Cannot use this in a terminal emulator; try the Emacs GUI")
     (fontaine--set-faces preset frame)
     (setq fontaine-current-preset preset)
     (unless frame


### PR DESCRIPTION
This is a proposal for improving the message in #12.

This issue is that when I start my Emacs I get the following message notified to me which is somewhat alarming:

![image](https://github.com/user-attachments/assets/aa25c064-507e-497a-8600-09ac13258815)

This proposal intends to make that exceptional situation quieter by logging a warning instead of displaying a `user-error`. Emacs is able to fall back on alternate fonts so this should not be an error if the user knows what they are doing. It should be logged though.

WDYT